### PR TITLE
Allow rejectUnauthorized to be passed as an option.

### DIFF
--- a/lib/thin.js
+++ b/lib/thin.js
@@ -148,7 +148,8 @@ Mitm.prototype.direct = function(req, res) {
 
   var params = {
     url: dest,
-    strictSSL: this.opts.strictSSL,
+    strictSSL: this.opts.strictSSL, 
+    rejectUnauthorized: this.opts.rejectUnauthorized,
     method: req.method,
     proxy: this.opts.proxy,
     headers: {}


### PR DESCRIPTION
 This is required to support proxying to HTTPs endpoints with invalid or self-signed certificates.

 Otherwise it would create an HTTP clientRequest with a default agent which caused the TLS connection to fail with an invalid certificate error.

 Ref:
 http://nodejs.org/api/tls.html#tls_tls_connect_options_callback