### PR TITLE
Add 'direct' method to allow server response modification.

### DIFF
--- a/lib/thin.js
+++ b/lib/thin.js
@@ -141,8 +141,7 @@ Mitm.prototype.removeInterceptors = function() {
   this.interceptors.length = 0;
 };
 
-
-Mitm.prototype.direct = function(req, res) {
+Mitm.prototype.forward = function(req, res, cb) {
   var log = this.log,
     self = this,
     path = url.parse(req.url).path,
@@ -172,16 +171,19 @@ Mitm.prototype.direct = function(req, res) {
 
   req.on('end', function() {
     params.body = buffer;
-    var r = request(params, function(err, response) {
-      if (err) {
-          self.emit('error', err);
-          res.end();
-      }
-    });
+    var proxyReq = request(params);
+    cb(proxyReq);
+  });
+};
 
+Mitm.prototype.direct = function(req, res) {
+  this.forward(req, res, function(r) {
+    r.on('error', function() {
+      self.emit('error', err);
+      res.end();
+    });
     r.pipe(res);
   });
-
 };
 
 module.exports = Mitm;

--- a/test/helpers/remote.js
+++ b/test/helpers/remote.js
@@ -23,6 +23,10 @@ function Remote() {
     });
   });
 
+  this.app.all('/response_modify', function(req, res) {
+    res.send('CHANGEME');
+  });
+
   this.app.all('/redirect', function(req, res) {
     res.redirect(302, '/not-found#fragment');
   });

--- a/test/proxy_test.js
+++ b/test/proxy_test.js
@@ -8,17 +8,20 @@ var Thin = require('../lib/thin'),
 describe('proxy', function() {
 
   var remote = new Remote;
-  var proxy = new Thin({followRedirect: false});
+  var proxy;
 
   before(function(done) {
+    proxy = new Thin({followRedirect: false});
     remote.listen(30000, 30001, function(err) {
       if (err) return done(err);
       proxy.listen(30002, 'localhost', done);
     });
   });
 
-  after(proxy.close.bind(proxy));
-  after(remote.close.bind(remote));
+  after(function() {
+    proxy.close();
+    remote.close();
+  });
 
   it('should work for HTTP GET methods', function(done) {
     request({
@@ -139,4 +142,33 @@ describe('proxy', function() {
     });
   });
 
+  it('should be possible to modify responses', function(done) {
+    proxy.use(function(clientReq, clientRes, next) {
+      proxy.forward(clientReq, clientRes, function(proxyReq) {
+        proxyReq.on('response', function (serverResponse) {
+          serverResponse.on('data', function(data) {
+            assert.equal(data.toString(), 'CHANGEME');
+            serverResponse.headers['content-length'] = 6;
+            clientRes.writeHead(serverResponse.statusCode, serverResponse.headers);
+            clientRes.end('WALRUS');
+          });
+        });
+        proxyReq.on('error', function () {
+          clientRes.end();
+        });
+      });
+    });
+    request({
+      method: 'GET',
+      proxy: 'http://localhost:30002',
+      url: 'http://localhost:30000/response_modify',
+      followRedirect: false
+    }, function(err, body, response) {
+      if (err) return done(err);
+      assert.equal(response.statusCode, 200);
+      assert.equal(body, 'WALRUS');
+      done()
+    });
+  });
 });
+


### PR DESCRIPTION
Hi, I'm interested in using 'thin' to modify server responses (e.g. change the content sent back from the server). While it is possible to do this already using middleware by issuing the request myself, it is nicer to be able to re-use the existing request logic.

This does not change the existing API and should be backwards compatible with any existing code.

This pull adds Mitm.prototype.forward for use by middleware. Middleware can inspect / modify the client request before forwarding. A callback fires once the request is forwarded, allowing the middleware to inspect or modify the origin server's response before sending it on to the client.

The test case shows just replacement, but it is also possible to perform streaming response modification.

Handling server response modification "in depth" involves being aware of content-length, content-encoding and possibly transfer-encoding, but the minimum requirement is to be able to get "in between" the server's response and the client, which is what this pull provides.