### PR TITLE
Add code & update examples for per-site certificate generation.

### DIFF
--- a/examples/badgerify.js
+++ b/examples/badgerify.js
@@ -10,7 +10,8 @@ var http = require('http');
 
 var proxy = new Thin({
     followRedirect: false,
-    strictSSL: true
+    strictSSL: true,
+    SNICallback: helpers.makeSNICallback()
 });
 
 /*

--- a/examples/helpers.js
+++ b/examples/helpers.js
@@ -1,5 +1,9 @@
 
-var zlib = require('zlib');
+var fs = require('fs'),
+    Promise = require('bluebird'),
+    pem = require('pem'),
+    tls = require('tls'),
+    zlib = require('zlib');
 
 /**
  * Get a stream transform to decompress an HTTP response (or null, if none required).
@@ -77,7 +81,66 @@ function sendOriginalResponse(clientRes, response) {
     response.pipe(clientRes);
 }
 
+/**
+ * Return an SNICallback to dynamically generate certificates signed by a CA.
+ *
+ * This allows you to install 'dummy.crt' as a root cert once, and then access all TLS sites
+ * without any further warnings from your browser.
+ *
+ * NOTE: This only works in node 0.12; in older versions it is not possible to generate certs
+ *       asynchronously, because there was no callback argument for SNICallback.
+ * NOTE: The OpenSSL command must be in your $PATH for the 'pem' library to work.
+ * NOTE: No cache eviction is implemented, this will eventually run out of memory if
+ *       implemented "as is" in a long-running process.
+ */
+function makeSNICallback() {
+    var caKey = fs.readFileSync(__dirname + '/../cert/dummy.key', 'utf8'),
+        caCert = fs.readFileSync(__dirname + '/../cert/dummy.crt', 'utf8'),
+        serial = Math.floor(Date.now() / 1000),
+        cache = {};
+
+    var ver = process.version.match(/^v(\d+)\.(\d+)/);
+    var canUseSNI = ver[1] > 1 || ver[2] >= 12; // >= 0.12.0
+    console.log('Per-site certificate generation is: ' + (canUseSNI ? 'ENABLED' : 'DISABLED'));
+    console.log('Feature requires SNI support (node >= v0.12), running version is: ' + ver[0]);
+
+    if(!canUseSNI) {
+        return undefined;
+    }
+    var createCertificateAsync = Promise.promisify(pem.createCertificate);
+
+    return function SNICallback(servername, cb) {
+        if(!cache.hasOwnProperty(servername)) {
+            // Slow path, put a promise for the cert into cache. Need to increment
+            // the serial or browsers will complain.
+            console.log('Generating new TLS certificate for: ' + servername);
+            var certOptions = {
+                commonName: servername,
+                serviceKey: caKey,
+                serviceCertificate: caCert,
+                serial: serial++,
+                days: 3650
+            };
+            cache[servername] = createCertificateAsync(certOptions).then(function (keys) {
+                return tls.createSecureContext({
+                    key: keys.clientKey,
+                    cert: keys.certificate,
+                    ca: caCert
+                }).context;
+            });
+        }
+        cache[servername].then(function (ctx) {
+            cb(null, ctx);
+        }).catch(function (err) {
+            console.log('Error generating TLS certificate: ', err);
+            cb(err, null);
+        });
+    }
+}
+
 module.exports = {
     sendModifiedResponse: sendModifiedResponse,
-    sendOriginalResponse: sendOriginalResponse
+    sendOriginalResponse: sendOriginalResponse,
+    makeSNICallback: makeSNICallback
 };
+

--- a/examples/unicorn-time.js
+++ b/examples/unicorn-time.js
@@ -12,7 +12,8 @@ var request = require('request');
 
 var proxy = new Thin({
     followRedirect: false,
-    strictSSL: false
+    strictSSL: false,
+    SNICallback: helpers.makeSNICallback()
 });
 
 var thirdPartyScripts = {

--- a/examples/upside-down.js
+++ b/examples/upside-down.js
@@ -11,7 +11,8 @@ var Jimp = require('jimp');
 
 var proxy = new Thin({
     followRedirect: false,
-    strictSSL: false
+    strictSSL: false,
+    SNICallback: helpers.makeSNICallback()
 });
 
 /*

--- a/lib/thin.js
+++ b/lib/thin.js
@@ -34,9 +34,11 @@ Mitm.prototype.listen = function(port, host, cb) {
     fs.unlinkSync(this.socket);
 
   var options = {
+    SNICallback: this.opts.SNICallback,
     key: fs.readFileSync(__dirname + '/../cert/dummy.key', 'utf8'),
     cert: fs.readFileSync(__dirname + '/../cert/dummy.crt', 'utf8')
   };
+
   // fake https server, MITM if you want
   this.httpsServer = https.createServer(options, this._handler.bind(this)).listen(this.socket);
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "devDependencies": {
     "mocha": "*",
     "express": "~3.0",
-    "jimp": "^0.2.3"
+    "jimp": "^0.2.3",
+    "bluebird": "^2.9.26",
+    "pem": "^1.7.2"
   },
   "scripts": {
     "test": "mocha -R spec --recursive"


### PR DESCRIPTION
OK, after this one, I think the proxy has all the features I need :)  Thanks again for this project, which is very useful for me.

Really only "need" the 1-line change to allow SNICallback, but I do think the example might be useful for some people. On the downside, the example adds two more devDeps "bluebird" (sigh) and "pem". 

Most intercepting proxies (e.g. Burp proxy, mitmproxy) dynamically generate certificates for accessed sites "on the fly", all signed by a single CA. If the user has installed the CA into their browser, they will be able to access any site without warnings. 

This requires the use of SNI (server name indication) in node.js so that the proxy can inspect the name of the server and generate a certificate with the right common name. Unfortunately, SNI is not usable in node < 0.12. The examples therefore enable dynamic cert generation if node.js can support it.

Without dynamic certs, the user must accept a certificate warning for every site, and it will not be possible to visit sites with HSTS (HTTP Strict Transport Security) such as Google or Gmail.

This pull request adds a tiny change to the library (options.SNICallback) for SNI support, and updates the examples to use it.

Tried hard to avoid using a promise library, but I just could not figure out another easy way to avoid race conditions during certificate generation.

### Without SNI

Often sub-frames and sub-resources (such as CSS & ad libraries) will fail to load because certificate warnings have not been accepted for third party sites:

![screen shot 2015-05-28 at 2 28 25 pm](https://cloud.githubusercontent.com/assets/203738/7852748/0bfe724c-0546-11e5-9074-a02334e06311.png)
 
### With SNI 

The page will load cleanly if dummy.crt is installed as a root certificate:

![screen shot 2015-05-28 at 2 33 10 pm](https://cloud.githubusercontent.com/assets/203738/7852779/86670832-0546-11e5-8ff1-02b308dc6f0e.png)

### Without SNI

It is not possible to visit an HSTS site at all (browser will not show an option to accept the certificate warning):

![screen shot 2015-05-28 at 2 37 45 pm](https://cloud.githubusercontent.com/assets/203738/7852801/308b4ee0-0547-11e5-8de0-a4a3df054ebd.png)

### With SNI

Popular sites with HSTS will work if the CA is installed:

![screen shot 2015-05-28 at 2 36 09 pm](https://cloud.githubusercontent.com/assets/203738/7852796/03c7b3ee-0547-11e5-8572-75c13e74e5b9.png)

### Certificate with SNI / dynamic cert gen:

![screen shot 2015-05-28 at 1 49 43 pm](https://cloud.githubusercontent.com/assets/203738/7852541/70b30cc4-0542-11e5-965d-3176f62f2be5.png)

### Certificate without SNI / dynamic cert gen:

![screen shot 2015-05-28 at 1 50 51 pm](https://cloud.githubusercontent.com/assets/203738/7852544/77d2ae6a-0542-11e5-80de-79079406966f.png)
